### PR TITLE
fix: fix mkdocs version here temporarily

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-mkdocs
+mkdocs>=0.17.3,<1
 mkdocs-material
 pymdown-extensions


### PR DESCRIPTION
mkdocs v1.0 was released hours ago. With the URL schema refactored, it is not compatible with current mkdocs-material version.

FYI: https://github.com/squidfunk/mkdocs-material/issues/834

(reproduced in my own repo)