### PR TITLE
A very initial Dockerfile to view ctf-wiki at local.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+FROM python:3.6 as build-stage
+MAINTAINER Yibai Zhang <xm1994@gmail.com>
+
+ADD . /opt/ctf-wiki/
+WORKDIR /opt/ctf-wiki
+RUN pip install -r requirements.txt && ./build.sh
+
+FROM alpine:3.8
+RUN apk add --update --no-cache \
+	lighttpd \
+    && rm -rf /var/cache/apk/*
+
+COPY --from=build-stage /opt/ctf-wiki/site /var/www/localhost/htdocs
+EXPOSE 80
+CMD ["lighttpd", "-D", "-f", "/etc/lighttpd/lighttpd.conf"]
+

--- a/README.md
+++ b/README.md
@@ -46,6 +46,13 @@ mkdocs serve
 
 **mkdocs 本地部署的网站是动态更新的，即当你修改并保存 md 文件后，刷新页面就能随之动态更新。**
 
+
+只是想本地浏览，并不想修改文档？试试 Docker 把！
+```
+docker run -d --name=ctf-wiki -p 4100:80 ctfwiki/ctf-wiki
+```
+随后即可在浏览器中访问 [http://localhost:4100/](http://localhost:4100/) 阅读 CTF Wiki 。
+
 ## How to practice？
 
 Wiki 中的所有题目在 [ctf-challenges](https://github.com/ctf-wiki/ctf-challenges) 仓库中，请根据对应的分类自行寻找。


### PR DESCRIPTION
ATT.
Just build and serve using lighttpd. Still need to change CDN resource to local. Please create a new issue for me if accepted.
And I also created a docker hub organization called ctfwiki (hyphen is not allowed by docker hub), more member need to be added.
`docker run -d xm1994/ctf-wiki:add-dockerfile` and will run it now.