### PR TITLE
修正amd64 下  IO_FILE_plus 中 vtable offset的错误

### DIFF
--- a/docs/pwn/linux/io_file/introduction.md
+++ b/docs/pwn/linux/io_file/introduction.md
@@ -68,7 +68,7 @@ _IO_2_1_stdin_
 
 但是事实上_IO_FILE结构外包裹着另一种结构_IO_FILE_plus，其中包含了一个重要的指针vtable指向了一系列函数指针。
 
-在libc2.23版本下，32位的vtable偏移为0x94，64位偏移为0x228
+在libc2.23版本下，32位的vtable偏移为0x94，64位偏移为0xd8
 
 ```
 struct _IO_FILE_plus


### PR DESCRIPTION
Thanks for contributing to CTF Wiki!

Before you submit this pull request, please read
- [CONTRIBUTING](https://github.com/ctf-wiki/ctf-wiki/wiki/Contributing-Guide)
- [CTF Wiki's Wiki](https://github.com/ctf-wiki/ctf-wiki/wiki)

Please remove these message before PR.
