### PR TITLE
fix wrong struct size in kernel_uaf

### DIFF
--- a/docs/pwn/linux/kernel/kernel_uaf.md
+++ b/docs/pwn/linux/kernel/kernel_uaf.md
@@ -227,7 +227,7 @@ struct cred {
 2. 释放其中一个，fork 一个新进程，那么这个新进程的 cred 的空间就会和之前释放的空间重叠
 3. 同时，我们可以通过另一个文件描述符对这块空间写，只需要将 uid，gid 改为 0，即可以实现提权到 root
 
-需要确定 cred 结构体的大小，有了源码，大小就很好确定了。计算一下是 0x8a（注意使用相同内核版本的源码）。
+需要确定 cred 结构体的大小，有了源码，大小就很好确定了。计算一下是 0xa8（注意使用相同内核版本的源码）。
 
 
 #### Exploit
@@ -250,7 +250,7 @@ int main()
 	int fd2 = open("/dev/babydev", 2);
 
 	// 修改 babydev_struct.device_buf_len 为 sizeof(struct cred)
-	ioctl(fd1, 0x10001, 0x8a);
+	ioctl(fd1, 0x10001, 0xa8);
 
 	// 释放 fd1
 	close(fd1);


### PR DESCRIPTION
fix #516 
slub分配时，0x8a和0xab 都在128-256这一块slab