### PR TITLE
fix git clone link

### DIFF
--- a/README-zh_CN.md
+++ b/README-zh_CN.md
@@ -46,7 +46,7 @@
 
 ```shell
 # 1. clone
-git clone git@github.com:ctf-wiki/ctf-wiki.git
+git clone https://github.com/ctf-wiki/ctf-wiki.git
 # 2. requirements
 pip install -r requirements.txt
 # generate static file in site/

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Of course, it can be deployed locally, do as following
 
 ```shell
 # 1. clone
-git clone git@github.com:ctf-wiki/ctf-wiki.git
+git clone https://github.com/ctf-wiki/ctf-wiki.git
 # 2. requirements
 pip install -r requirements.txt
 # generate static file in site/


### PR DESCRIPTION
fix git clone link to using https protocol, instead of git protocol