### PR TITLE
Travis CI: Lint code for Python syntax errors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,8 @@
 language: python
 cache: pip
-python:
-  - 3.6
-install:
-  - pip install -r requirements.txt
+python: 3.7
+install: pip install flake8 -r requirements.txt
+before_script: flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
 script: chmod +x build.sh && ./build.sh
 deploy:
   skip_cleanup: true


### PR DESCRIPTION
$ __flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics__
```
./docs/crypto/signature/service.py:22:157: E999 SyntaxError: invalid syntax
print "Welcome to admin's music portal.\nTo verify that you are the owner of this service\nsend the public key which will verify the following signature :\n"
                                                                                                                                                            ^
./utils/md2rst.py:3:9: E999 SyntaxError: invalid syntax
print sys.argv
        ^
2     E999 SyntaxError: invalid syntax
2
```