### PR TITLE
Fix some link error

### DIFF
--- a/docs/crypto/asymmetric/discrete-log/ecc.md
+++ b/docs/crypto/asymmetric/discrete-log/ecc.md
@@ -3,7 +3,7 @@
 
 
 
-# ETC
+# ECC
 
 
 ## Overview

--- a/docs/pwn/linux/glibc-heap/tcache_attack-zh.md
+++ b/docs/pwn/linux/glibc-heap/tcache_attack-zh.md
@@ -1869,7 +1869,7 @@ if __name__=='__main__':
 
 ##### 基本信息
 
-参见[unlink HITCON stkof 简介](./unlink.md#2014 HITCON stkof)
+参见[unlink HITCON stkof 简介](./unlink-zh.md#2014 HITCON stkof)
 
 ##### libc 2.26 tcache 利用方法
 

--- a/docs/pwn/linux/io_file/exploit-in-libc2.24-zh.md
+++ b/docs/pwn/linux/io_file/exploit-in-libc2.24-zh.md
@@ -1,3 +1,4 @@
+[EN](./exploit-in-libc2.24.md) | [ZH](./exploit-in-libc2.24-zh.md)
 # glibc 2.24下 IO_FILE 的利用
 
 ## 介绍

--- a/docs/pwn/linux/io_file/exploit-in-libc2.24.md
+++ b/docs/pwn/linux/io_file/exploit-in-libc2.24.md
@@ -1,4 +1,4 @@
-[EN](./exploit-in-libc2.md) | [ZH](./exploit-in-libc2-zh.md)
+[EN](./exploit-in-libc2.24.md) | [ZH](./exploit-in-libc2.24-zh.md)
 # glibc 2.24 Utilization of IO_FILE
 
 

--- a/docs/reverse/windows/anti-debug/checkremotedebuggerpresent-zh.md
+++ b/docs/reverse/windows/anti-debug/checkremotedebuggerpresent-zh.md
@@ -60,4 +60,4 @@ int main(int argc, char *argv[])
 
 我们可以直接修改`isDebuggerPresent`的值或修改跳转条件来绕过(注意不是`CheckRemoteDebuggerPresent`的izhi, 它的返回值是用于表示函数是否正确执行).
 
-但如果要针对`CheckRemoteDebuggerPresent`这个api函数进行修改的话. 首先要知道`CheckRemoteDebuggerPresent`内部其实是通过调用`NtQueryInformationProcess`来完成功能的. 而我们就需要对`NtQueryInformationProcess`的返回值进行修改. 我们将在[ NtQueryInformationProcess 篇](./ntqueryinformationprocess/index.html)进行介绍.
+但如果要针对`CheckRemoteDebuggerPresent`这个api函数进行修改的话. 首先要知道`CheckRemoteDebuggerPresent`内部其实是通过调用`NtQueryInformationProcess`来完成功能的. 而我们就需要对`NtQueryInformationProcess`的返回值进行修改. 我们将在[ NtQueryInformationProcess 篇](./ntqueryinformationprocess-zh.md)进行介绍.

--- a/docs/reverse/windows/anti-debug/example-zh.md
+++ b/docs/reverse/windows/anti-debug/example-zh.md
@@ -134,11 +134,11 @@ if ( IsDebuggerPresent() == 1 )     // 2. API: IsDebuggerPresent()
 
 显然, 输入的`password`正确, 就会输出提示`Your password is correct.`. ??? 不觉得奇怪吗. 难道`I have a pen.`就是我们的flag了吗? 不不不当然不是. 这其实是一个陷阱, 既然你知道了`I have a pen.`那么就肯定有通过某种逆向手段在对程序进行分析. 所以接下来的部分就开始进行一些反调试或其他的检测手段(实际中也可以出现这样的陷阱).
 
-一开始的是`IsDebuggerPresent()`, 根据返回结果判断是否存在调试.如果不太清楚的话, 可以返回去看 [IsDebuggerPresent()](./isdebuggerpresent/index.html) 篇
+一开始的是`IsDebuggerPresent()`, 根据返回结果判断是否存在调试.如果不太清楚的话, 可以返回去看 [IsDebuggerPresent()](./isdebuggerpresent-zh.md) 篇
 
 ## NtGlobalFlag
 
-接下来是检测`NtGlobalFlag`这个字段的标志位. 通过检测PEB的字段值是否为`0x70`来检测调试器, 如果不太清楚的话, 可以返回去看 [NtGlobalFlag](./ntglobalflag/index.html) 篇
+接下来是检测`NtGlobalFlag`这个字段的标志位. 通过检测PEB的字段值是否为`0x70`来检测调试器, 如果不太清楚的话, 可以返回去看 [NtGlobalFlag](./ntglobalflag-zh.md) 篇
 
 ``` c
 if ( sub_401120() == 0x70 )         // 3. 检测PEB的0x68偏移处是否为0x70. 检测NtGlobalFlag()
@@ -176,7 +176,7 @@ if ( pbDebuggerPresent )            // 4. API: CheckRemoteDebuggerPresent()
     exit(1);
 }
 ```
-这里我顺便在注释里列出了`CheckRemoteDebuggerPresent()`这个API的函数原型. 如果检测到调试器的存在, 会将`pbDebuggerPresent`设置为一个非零值. 根据其值检测调试器([CheckRemoteDebuggerPresent()](./checkremotedebuggerpresent/index.html) 篇)
+这里我顺便在注释里列出了`CheckRemoteDebuggerPresent()`这个API的函数原型. 如果检测到调试器的存在, 会将`pbDebuggerPresent`设置为一个非零值. 根据其值检测调试器([CheckRemoteDebuggerPresent()](./checkremotedebuggerpresent-zh.md) 篇)
 
 
 ## 时间差检测

--- a/docs/reverse/windows/anti-debug/example.md
+++ b/docs/reverse/windows/anti-debug/example.md
@@ -248,14 +248,14 @@ if ( IsDebuggerPresent() == 1 )     // 2. API: IsDebuggerPresent()
 Obviously, if the input `password` is correct, it will output the prompt `Your password is correct.`. ??? Not surprising. Is it `I have a pen.` is our flag? No, no, of course not. This is actually a trap. Since you know `I have a pen.` then there is definitely some way to analyze the program through some reverse means. So the next part will start some anti-debugging or other means of detection (actual Such a trap can also occur in the middle).
 
 
-At the beginning is `IsDebuggerPresent()`, which determines if there is debugging based on the returned result. If you are not sure, you can go back and look at [IsDebuggerPresent()](./isdebuggerpresent/index.html)
+At the beginning is `IsDebuggerPresent()`, which determines if there is debugging based on the returned result. If you are not sure, you can go back and look at [IsDebuggerPresent()](./isdebuggerpresent.md)
 
 
 ## NtGlobalFlag
 
 
 
-Next is to detect the flag of the `NtGlobalFlag` field. Detect the debugger by checking if the field value of the PEB is `0x70`. If it is not clear, you can go back and look at [NtGlobalFlag](./ntglobalflag/index.html )
+Next is to detect the flag of the `NtGlobalFlag` field. Detect the debugger by checking if the field value of the PEB is `0x70`. If it is not clear, you can go back and look at [NtGlobalFlag](./ntglobalflag.md )
 
 
 ``` c
@@ -325,7 +325,7 @@ if ( pbDebuggerPresent )            // 4. API: CheckRemoteDebuggerPresent()
 
 ```
 
-Here I will list the function prototype of the `CheckRemoteDebuggerPresent()` API in the comments. If the debugger is detected, `pbDebuggerPresent` will be set to a non-zero value. Detect the debugger based on its value ([CheckRemoteDebuggerPresent( )](./checkremotedebuggerpresent/index.html)
+Here I will list the function prototype of the `CheckRemoteDebuggerPresent()` API in the comments. If the debugger is detected, `pbDebuggerPresent` will be set to a non-zero value. Detect the debugger based on its value ([CheckRemoteDebuggerPresent( )](./checkremotedebuggerpresent.md)
 
 
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -116,7 +116,7 @@ nav:
             - Discrete Log Correlation:
                 - Discrete Logarithm: crypto/asymmetric/discrete-log/discrete-log-zh.md
                 - Elgamal: crypto/asymmetric/discrete-log/elgamal-zh.md 
-                - ECC: crypto/asymmetric/discrete-log/ecc-zh
+                - ECC: crypto/asymmetric/discrete-log/ecc-zh.md
             - Lattice-based Cryptography:
                 - Lattice Overview: crypto/asymmetric/lattice/overview-zh.md
                 - Introduction to Lattices: crypto/asymmetric/lattice/introduction-zh.md


### PR DESCRIPTION
I found some link errors in document and fix it.
Here is the list of errors fixed.
```
FIXED -  A relative path to 'crypto/asymmetric/discrete-log/ecc-zh' is included in the 'nav' configuration, which is not found in the documentation files
FIXED -  Documentation file 'pwn\linux\glibc-heap\tcache_attack-zh.md' contains a link to 'pwn\linux\glibc-heap\unlink.md' which is not found in the documentation files.
FIXED -  Documentation file 'pwn\linux\io_file\exploit-in-libc2.24.md' contains a link to 'pwn\linux\io_file\exploit-in-libc2.md' which is not found in the documentation files.
FIXED -  Documentation file 'pwn\linux\io_file\exploit-in-libc2.24.md' contains a link to 'pwn\linux\io_file\exploit-in-libc2-zh.md' which is not found in the documentation files.
FIXED -  Documentation file 'reverse\windows\anti-debug\checkremotedebuggerpresent-zh.md' contains a link to 'reverse\windows\anti-debug\ntqueryinformationprocess\index.html' which is not found in the documentation files.
FIXED -  Documentation file 'reverse\windows\anti-debug\example-zh.md' contains a link to 'reverse\windows\anti-debug\isdebuggerpresent\index.html' which is not found in the documentation files.
FIXED -  Documentation file 'reverse\windows\anti-debug\example-zh.md' contains a link to 'reverse\windows\anti-debug\ntglobalflag\index.html' which is not found in the documentation files.
FIXED -  Documentation file 'reverse\windows\anti-debug\example-zh.md' contains a link to 'reverse\windows\anti-debug\checkremotedebuggerpresent\index.html' which is not found in the documentation files.
FIXED -  Documentation file 'reverse\windows\anti-debug\example.md' contains a link to 'reverse\windows\anti-debug\isdebuggerpresent\index.html' which is not found in the documentation files.
FIXED -  Documentation file 'reverse\windows\anti-debug\example.md' contains a link to 'reverse\windows\anti-debug\ntglobalflag\index.html' which is not found in the documentation files.
FIXED -  Documentation file 'reverse\windows\anti-debug\example.md' contains a link to 'reverse\windows\anti-debug\checkremotedebuggerpresent\index.html' which is not found in the documentation files.
FIXED -  In crypto\asymmetric\discrete-log\ecc.md , ECC was mistranslated into ETC.
```