### PR TITLE
Update large_bin_attack-zh.md

### DIFF
--- a/docs/pwn/linux/glibc-heap/large_bin_attack-zh.md
+++ b/docs/pwn/linux/glibc-heap/large_bin_attack-zh.md
@@ -294,9 +294,9 @@ large bin 某一个序列的 bin 中有一个 chunk 大小是 `0x410`
 
 
 ```c
-victim->bk_nextsize = fwd->nextsize
+victim->bk_nextsize = fwd->bk_nextsize
 // then
-victim->bk->nextsize->fd_nextsize = victim;
+victim->bk_nextsize->fd_nextsize = victim;
 ```
 
 

--- a/docs/pwn/linux/glibc-heap/large_bin_attack-zh.md
+++ b/docs/pwn/linux/glibc-heap/large_bin_attack-zh.md
@@ -319,23 +319,32 @@ addr2->fd_nextsize = victim;
 
 接着还存着另外一个利用：
 
+```c
+bck = fwd->bk;
+// ......
+mark_bin (av, victim_index);
+victim->bk = bck;
+victim->fd = fwd;
+fwd->bk = victim;
+bck->fd = victim;
+```
 
-
-![](./figure/large_bin_attack/large_bin_attack14.png)
 
 
 
 
 
 ```c
-fwd->bk = victim;
+bck->fd = victim;
 // 等价于
-*(addr+1) = victim;
+(fwd->bk)->fd = victim;
+// 等价于
+*(addr1+2) = victim;
 ```
 
 
 
-修改了 stack_var1 的值。
+修改了 `stack_var1` 的值。
 
 
 

--- a/docs/pwn/linux/glibc-heap/large_bin_attack.md
+++ b/docs/pwn/linux/glibc-heap/large_bin_attack.md
@@ -473,7 +473,7 @@ In detail:
 ```c
 victim->bk_nextsize = fwd->bk_nextsize;
 // then
-victim->bk->nextsize->fd_nextsize = victim;
+victim->bk_nextsize->fd_nextsize = victim;
 ```
 
 Here `fwd->bk_nextsize` stores `&stack_var2 - 4`, so the above statements equals to:

--- a/docs/pwn/linux/glibc-heap/large_bin_attack.md
+++ b/docs/pwn/linux/glibc-heap/large_bin_attack.md
@@ -413,7 +413,7 @@ Then we modify the chunk of P2 through some kind of vulnerability:
 
 
 
-Then we malloc a new chunk. At this time, because the fastbin is empty, the program traverses the unsorte bin. At that time, when the chunk in the unsorte bin is large bin, first determine whether the current chunk size is smaller than bck-&gt;bk. The size, which is the smallest chunk in the large bin, if it is, is added directly to the end. If not, it traverses the large bin until it finds that the size of a chunk is less than or equal to the current chunk size (the chunks of the large bin are aligned from large to small). Then insert the current chunk into the two linked lists of the large bin.
+Then we malloc a new chunk. At this time, because the fastbin is empty, the program traverses the unsorted bin. At that time, when the chunk in the unsorted bin is a large chunk, first determine whether the current chunk size is smaller than `bck->bk`. The size, which is the smallest chunk in the large bin, if it is, is added directly to the end. If not, it traverses the large bin until it finds that the size of a chunk is less than or equal to the current chunk size (the chunks of the large bin are aligned from large to small). Then insert the current chunk into the two linked lists of the large bin.
 
 
 The `fd_nextsize` in the large bin chunk points to the first chunk in the list that is smaller than itself, and `bk_nextsize` points to the first chunk larger than itself.
@@ -469,3 +469,35 @@ mark_bin (off, victim_index);
 
 Fwd is now P2, victim is P3, and the two variables on the stack can be modified to `victim`.
 
+In detail:
+```c
+victim->bk_nextsize = fwd->bk_nextsize;
+// then
+victim->bk->nextsize->fd_nextsize = victim;
+```
+
+Here `fwd->bk_nextsize` stores `&stack_var2 - 4`, so the above statements equals to:
+```c
+(&stack_var2 - 4)->fd_nextsize = victim;
+// equals to
+*(&stack_var2 - 4 + 4) = victim;
+```
+, modifying `stack_var2`.
+
+And then, we set `bck = fwd->bk`, and the following code will be executed:
+```c
+mark_bin (off, victim_index);
+victim->bk = bck;
+victim->fd = fwd;
+fwd->bk = victim;
+bck->fd = victim;
+```
+
+Here we have:
+```c
+fwd->bk = victim;
+// equals to
+*(&stack_var1 - 2 + 2) = victim
+```
+
+Thus modifying `stack_var1`.


### PR DESCRIPTION
At the end of this post where we modify `stack_var1`, I think the statement that actually works should be `bck->fd = victim`.

When we modify `stack_var2`, the vuln code looks like this：
```c
else
  {
    victim->fd_nextsize = fwd;
    victim->bk_nextsize = fwd->bk_nextsize;
    fwd->bk_nextsize = victim;
    victim->bk_nextsize->fd_nextsize = victim;
  }
bck = fwd->bk;
```

In my point of view, we first assign `fwd->bk`, namely `addr1` to the variable `bck`, and therefore `bck->fd = victim` equals to `*(addr1+2) = victim`，which is consistent with `&stack_var1 - 2` in the original `large_bin_attack.c` file.

If `fwd->bk = victim` is what actually works here, it should be equal to `*(addr+3) = victim`, not `+1`. Anyway, neither seems consistent with `&stack_var1 - 2`.

Sometimes however, statement `fwd->bk = victim` does help in exploitation, but not here.