### PR TITLE
修正共模攻击的一处小错误

### DIFF
--- a/docs/crypto/asymmetric/rsa/rsa_module_attack-zh.md
+++ b/docs/crypto/asymmetric/rsa/rsa_module_attack-zh.md
@@ -273,13 +273,13 @@ c_1 = m^{e_1}\bmod N \\
 c_2 = m^{e_2}\bmod N
 $$
 
-当攻击者截获 $c_1$ 和 $c_2$ 后，就可以恢复出明文。用扩展欧几里得算法求出 $re_1+se_2=1\bmod n$ 的两个整数 $r$ 和 $s$，由此可得：
+当攻击者截获 $c_1$ 和 $c_2$ 后，就可以恢复出明文。用扩展欧几里得算法求出 $re_1+se_2=1$ 的两个整数 $r$ 和 $s$，由此可得：
 
 $$
 \begin{align*}
-c_{1}^{r}c_{2}^{s} &\equiv m^{re_1}m^{se_2}\bmod n\\
-&\equiv m^{(re_1+se_2)} \bmod n\\
-&\equiv m\bmod n
+c_{1}^{r}c_{2}^{s} &\equiv m^{re_1}m^{se_2}\pmod n\\
+&\equiv m^{(re_1+se_2)} \pmod n\\
+&\equiv m\pmod n
 \end{align*}
 $$
 


### PR DESCRIPTION
在这里，exgcd是用来求“使得 $re_1+se_2$ 恰等于1”（而不是模n意义下等于1）的解。
另外，下面有几处 \bmod 应该改为 \pmod。