### PR TITLE
Upgrading mkdocs material theme to v5.0

### DIFF
--- a/mkdocs-zh.yml
+++ b/mkdocs-zh.yml
@@ -304,10 +304,10 @@ theme:
   palette:
     primary: 'white'
     accent: 'red'
-  logo:
-    icon: 'school'
-  feature:
-    tabs: true
+  icon:
+    logo: 'material/school'
+  features:
+    - tabs
   font:
     text: 'Noto Sans'
     code: 'Source Code Pro'

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -15,7 +15,7 @@ copyright: 'Copyright &copy; 2016 - 2020 CTF Wiki Team'
 # Contents
 nav:
     - Introduction:
-        - Getting Started: index.md 
+        - Getting Started: index.md
         - CTF History: introduction/history-zh.md
         - Introduction to CTF Competition Form: introduction/mode-zh.md
         - CTF Contest Content: introduction/content-zh.md
@@ -33,21 +33,21 @@ nav:
         - Forensic Steganography: misc/prefix-zh.md
         - Image Analysis:
             - Introduction to Image Analysis: misc/picture/introduction-zh.md
-            - PNG: misc/picture/png-zh.md 
-            - JPG: misc/picture/jpg-zh.md 
-            - GIF: misc/picture/gif-zh.md 
+            - PNG: misc/picture/png-zh.md
+            - JPG: misc/picture/jpg-zh.md
+            - GIF: misc/picture/gif-zh.md
         - Traffic Packet Analysis:
             - Introduction to Traffic Packet Analysis: misc/traffic/introduction-zh.md
             - PCAP File Repairing: misc/traffic/fix-zh.md
             - Protocol Analysis:
                 - Overview of Protocol Analysis: misc/traffic/protocols/README-zh.md
-                - Wireshark: misc/traffic/protocols/Wireshark-zh.md 
-                - HTTP: misc/traffic/protocols/HTTP-zh.md 
-                - HTTPS: misc/traffic/protocols/HTTPS-zh.md 
-                - FTP: misc/traffic/protocols/FTP-zh.md 
-                - DNS: misc/traffic/protocols/DNS-zh.md 
-                - WIFI: misc/traffic/protocols/WIFI-zh.md 
-                - USB: misc/traffic/protocols/USB-zh.md 
+                - Wireshark: misc/traffic/protocols/Wireshark-zh.md
+                - HTTP: misc/traffic/protocols/HTTP-zh.md
+                - HTTPS: misc/traffic/protocols/HTTPS-zh.md
+                - FTP: misc/traffic/protocols/FTP-zh.md
+                - DNS: misc/traffic/protocols/DNS-zh.md
+                - WIFI: misc/traffic/protocols/WIFI-zh.md
+                - USB: misc/traffic/protocols/USB-zh.md
             - Data Extraction: misc/traffic/data-zh.md
         - Compressed Package Analysis:
             - ZIP Format: misc/archive/zip-zh.md
@@ -73,7 +73,7 @@ nav:
             - Pseudo Random Number Generator:
                 - Introduction: crypto/streamcipher/prng/intro-zh.md
                 - Cryptographic Security Pseudo-random Number Generator: crypto/streamcipher/prng/csprng-zh.md
-                - Challenge Examples: crypto/streamcipher/prng/problem-zh.md 
+                - Challenge Examples: crypto/streamcipher/prng/problem-zh.md
             - Linear Congruence Generator:
                 - Introduction: crypto/streamcipher/lcg/intro-zh.md
                 - Example: crypto/streamcipher/lcg/challenge-zh.md
@@ -82,24 +82,24 @@ nav:
                 - Linear Feedback Shift Register: crypto/streamcipher/fsr/lfsr-zh.md
                 - Nonlinear Feedback Shift Register: crypto/streamcipher/fsr/nfsr-zh.md
             - Special Stream Cipher:
-                - RC4: crypto/streamcipher/special/rc4-zh.md 
+                - RC4: crypto/streamcipher/special/rc4-zh.md
         - Block Cipher:
             - Introduction to Block Cipher: crypto/blockcipher/introduction-zh.md
-            - ARX: crypto/blockcipher/arx-operations-zh.md 
+            - ARX: crypto/blockcipher/arx-operations-zh.md
             - DES: crypto/blockcipher/des-zh.md
-            - IDEA: crypto/blockcipher/idea-zh.md 
-            - AES: crypto/blockcipher/aes-zh.md 
-            - Simon and Speck: crypto/blockcipher/simon-speck-zh.md 
+            - IDEA: crypto/blockcipher/idea-zh.md
+            - AES: crypto/blockcipher/aes-zh.md
+            - Simon and Speck: crypto/blockcipher/simon-speck-zh.md
             - Group Mode:
                 - Introduction: crypto/blockcipher/mode/introduction-zh.md
                 - Padding Methods: crypto/blockcipher/mode/padding-zh.md
-                - ECB: crypto/blockcipher/mode/ecb-zh.md 
-                - CBC: crypto/blockcipher/mode/cbc-zh.md 
-                - PCBC: crypto/blockcipher/mode/pcbc-zh.md 
-                - CFB: crypto/blockcipher/mode/cfb-zh.md 
+                - ECB: crypto/blockcipher/mode/ecb-zh.md
+                - CBC: crypto/blockcipher/mode/cbc-zh.md
+                - PCBC: crypto/blockcipher/mode/pcbc-zh.md
+                - CFB: crypto/blockcipher/mode/cfb-zh.md
                 - OFB: crypto/blockcipher/mode/ofb-zh.md
                 - CTR: crypto/blockcipher/mode/ctr-zh.md
-                - Padding Oracle Attack: crypto/blockcipher/mode/padding-oracle-attack-zh.md 
+                - Padding Oracle Attack: crypto/blockcipher/mode/padding-oracle-attack-zh.md
         - Asymmetric Cryptography:
             - Introduction to Asymmetric Cryptography: crypto/asymmetric/introduction-zh.md
             - RSA:
@@ -115,7 +115,7 @@ nav:
             - Knapsack Cipher: crypto/asymmetric/knapsack/knapsack-zh.md
             - Discrete Log Correlation:
                 - Discrete Logarithm: crypto/asymmetric/discrete-log/discrete-log-zh.md
-                - Elgamal: crypto/asymmetric/discrete-log/elgamal-zh.md 
+                - Elgamal: crypto/asymmetric/discrete-log/elgamal-zh.md
                 - ECC: crypto/asymmetric/discrete-log/ecc-zh.md
             - Lattice-based Cryptography:
                 - Lattice Overview: crypto/asymmetric/lattice/overview-zh.md
@@ -124,10 +124,10 @@ nav:
                 - CVP: crypto/asymmetric/lattice/cvp-zh.md
         - Hash Function:
             - Introduction to the Hash Function: crypto/hash/introduction-zh.md
-            - MD5: crypto/hash/md5-zh.md 
+            - MD5: crypto/hash/md5-zh.md
             - SHA1: crypto/hash/sha1-zh.md
-            - FNV: crypto/hash/fnv-zh.md 
-            - Hash Attack: crypto/hash/attack-zh.md 
+            - FNV: crypto/hash/fnv-zh.md
+            - Hash Attack: crypto/hash/attack-zh.md
             - Challenge Examples: crypto/hash/complex-zh.md
         - Digital Signature:
             - Introduction to Digital Signatures: crypto/signature/introduction-zh.md
@@ -147,10 +147,10 @@ nav:
         - SSRF Server Request Forgery: web/ssrf-zh.md
         - PHP Code Auditing: web/php/php-zh.md
     - Assembly:
-        - x86_x64: assembly/x86-x64/readme-zh.md 
-        - mips: assembly/mips/readme-zh.md 
-        - arm: assembly/arm/readme-zh.md 
-    - Executable: 
+        - x86_x64: assembly/x86-x64/readme-zh.md
+        - mips: assembly/mips/readme-zh.md
+        - arm: assembly/arm/readme-zh.md
+    - Executable:
         - ELF file:
             - ELF File Basic Structure: executable/elf/elf-structure-zh.md
             - Program Loading: executable/elf/program-loading-zh.md
@@ -167,14 +167,14 @@ nav:
             - Common Encryption Algorithms and Code Recognition: reverse/Identify-Encode-Encryption/introduction-zh.md
             - Labyrinth Problem: reverse/maze/maze-zh.md
             - Virtual Machine Command Analysis: reverse/vm/vm-zh.md
-            - Unicorn Engine Introduction: reverse/unicorn/introduction-zh.md 
+            - Unicorn Engine Introduction: reverse/unicorn/introduction-zh.md
         - Linux Reverse:
             - Linux Reverse Technology:
-                - LD_PRELOAD: reverse/linux/ld_preload-zh.md 
-                - Incorrect Disassembly Fix: reverse/linux/false-disasm-zh.md 
-                - Detecting Breakpoints Bypassing: reverse/linux/detect-bp-zh.md 
-                - Detecting Debugging Bypassing: reverse/linux/detect-dbg-zh.md 
-        - Windows Reverse: 
+                - LD_PRELOAD: reverse/linux/ld_preload-zh.md
+                - Incorrect Disassembly Fix: reverse/linux/false-disasm-zh.md
+                - Detecting Breakpoints Bypassing: reverse/linux/detect-bp-zh.md
+                - Detecting Debugging Bypassing: reverse/linux/detect-dbg-zh.md
+        - Windows Reverse:
             - Shelling Technology:
                 - Introduction to the Protective case: reverse/windows/unpack/packer-introduction-zh.md
                 - Single Step Tracking Method: reverse/windows/unpack/trace-zh.md
@@ -187,25 +187,25 @@ nav:
                 - Manually Find the IAT and Rebuild It Using ImportREC: reverse/windows/unpack/manually-fix-iat-zh.md
                 - DLL File Unpacking: reverse/windows/unpack/unpack-dll-zh.md
             - Anti-debugging Technology:
-                - NtGlobalFlag: reverse/windows/anti-debug/ntglobalflag-zh.md 
-                - Heap Flags: reverse/windows/anti-debug/heap-flags-zh.md 
-                - The Heap: reverse/windows/anti-debug/the-heap-zh.md 
-                - Interrupt 3: reverse/windows/anti-debug/int-3-zh.md 
-                - IsDebuggerPresent: reverse/windows/anti-debug/isdebuggerpresent-zh.md 
-                - CheckRemoteDebuggerPresent: reverse/windows/anti-debug/checkremotedebuggerpresent-zh.md 
-                - NtQueryInformationProcess: reverse/windows/anti-debug/ntqueryinformationprocess-zh.md 
+                - NtGlobalFlag: reverse/windows/anti-debug/ntglobalflag-zh.md
+                - Heap Flags: reverse/windows/anti-debug/heap-flags-zh.md
+                - The Heap: reverse/windows/anti-debug/the-heap-zh.md
+                - Interrupt 3: reverse/windows/anti-debug/int-3-zh.md
+                - IsDebuggerPresent: reverse/windows/anti-debug/isdebuggerpresent-zh.md
+                - CheckRemoteDebuggerPresent: reverse/windows/anti-debug/checkremotedebuggerpresent-zh.md
+                - NtQueryInformationProcess: reverse/windows/anti-debug/ntqueryinformationprocess-zh.md
                 - Flower command: reverse/windows/anti-debug/junk-code-zh.md
                 - Anti-debug technical example: reverse/windows/anti-debug/example-zh.md
     - Pwn:
         - Pwn Overview:
-            - pwn/readme-zh.md 
+            - pwn/readme-zh.md
         - Linux Pwn:
             - Security Protection Mechanism:
-                - Canary: pwn/linux/mitigation/canary-zh.md 
+                - Canary: pwn/linux/mitigation/canary-zh.md
             - Stack Overflow:
                 - Stack Introduction: pwn/linux/stackoverflow/stack-intro-zh.md
                 - Stack Overflow Principle: pwn/linux/stackoverflow/stackoverflow-basic-zh.md
-                - Basic ROP: pwn/linux/stackoverflow/basic-rop-zh.md 
+                - Basic ROP: pwn/linux/stackoverflow/basic-rop-zh.md
                 - Intermediate ROP: pwn/linux/stackoverflow/medium-rop-zh.md
                 - Advanced ROP: pwn/linux/stackoverflow/advanced-rop-zh.md
                 - ROP Tricks: pwn/linux/stackoverflow/fancy-rop-zh.md
@@ -219,17 +219,17 @@ nav:
                 - Heap Overview: pwn/linux/glibc-heap/heap_overview-zh.md
                 - Heap Related Data Structure: pwn/linux/glibc-heap/heap_structure-zh.md
                 - In-depth Understanding of Ptmalloc2:
-                    - Implementation: pwn/linux/glibc-heap/implementation/overview-zh.md 
+                    - Implementation: pwn/linux/glibc-heap/implementation/overview-zh.md
                     - Basic Functions in the heap implementation: pwn/linux/glibc-heap/implementation/basic-zh.md
                     - Heap Initialization: pwn/linux/glibc-heap/implementation/heap-init-zh.md
                     - Allocate Heap Memory: pwn/linux/glibc-heap/implementation/malloc-zh.md
                     - Free Heap Memory: pwn/linux/glibc-heap/implementation/free-zh.md
                     - Tcache: pwn/linux/glibc-heap/implementation/tcache-zh.md
-                    - malloc_state: pwn/linux/glibc-heap/implementation/malloc_state-zh.md 
-                    - Other: pwn/linux/glibc-heap/implementation/misc-zh.md 
+                    - malloc_state: pwn/linux/glibc-heap/implementation/malloc_state-zh.md
+                    - Other: pwn/linux/glibc-heap/implementation/misc-zh.md
                 - Heap Overflow: pwn/linux/glibc-heap/heapoverflow_basic-zh.md
                 - Heap-based Off-By-One: pwn/linux/glibc-heap/off_by_one-zh.md
-                - Chunk Extend/Overlapping: pwn/linux/glibc-heap/chunk_extend_overlapping-zh.md 
+                - Chunk Extend/Overlapping: pwn/linux/glibc-heap/chunk_extend_overlapping-zh.md
                 - Unlink: pwn/linux/glibc-heap/unlink-zh.md
                 - Use After Free: pwn/linux/glibc-heap/use_after_free-zh.md
                 - Fastbin Attack: pwn/linux/glibc-heap/fastbin_attack-zh.md
@@ -241,7 +241,7 @@ nav:
                 - House of Lore: pwn/linux/glibc-heap/house_of_lore-zh.md
                 - House of Orange: pwn/linux/glibc-heap/house_of_orange-zh.md
                 - House of Rabbit: pwn/linux/glibc-heap/house_of_rabbit-zh.md
-                - House of Roman: pwn/linux/glibc-heap/house_of_roman-zh.md 
+                - House of Roman: pwn/linux/glibc-heap/house_of_roman-zh.md
             - IO_FILE Related:
                 - FILE Structure Description: pwn/linux/io_file/introduction-zh.md
                 - Forged Vtable to Hijack Control Flow: pwn/linux/io_file/fake-vtable-exploit-zh.md
@@ -254,7 +254,7 @@ nav:
                 - Introduction to The Principle of Integer Overflow: pwn/linux/integeroverflow/intof-zh.md
             - Sandbox Escape:
                 - Python Sandbox Escape: pwn/linux/sandbox/python-sandbox-escape-zh.md
-            - Linux Kernel: 
+            - Linux Kernel:
                 - Environment Setup: pwn/linux/kernel/environment-zh.md
                 - Basics: pwn/linux/kernel/basic_knowledge-zh.md
                 - Kernel-UAF: pwn/linux/kernel/kernel_uaf-zh.md
@@ -276,17 +276,17 @@ nav:
                 - Stack Introduction: pwn/windows/stackoverflow/stack-introduce-zh.md
                 - Stack Overflow Principle: pwn/windows/stackoverflow/stackoverflow-basic-zh.md
                 - shellcode-in-stack: pwn/windows/stackoverflow/shellcode-in-stack-zh.md
-    
+
     - Android:
         - Android Development Basics: android/basic_develop/basic_develop-zh.md
         - Android Application Operating Mechanism Brief:
-            - Basics: android/basic_operating_mechanism/readme-zh.md 
-            - The Operating Mechanism of the Java Layer in Android: 
-                - Andriod Native: android/basic_operating_mechanism/java_layer/readme-zh.md 
-                - Smali Introduction: android/basic_operating_mechanism/java_layer/smali/smali-zh.md 
+            - Basics: android/basic_operating_mechanism/readme-zh.md
+            - The Operating Mechanism of the Java Layer in Android:
+                - Andriod Native: android/basic_operating_mechanism/java_layer/readme-zh.md
+                - Smali Introduction: android/basic_operating_mechanism/java_layer/smali/smali-zh.md
                 - Dex and ODEX:
-                    - DEX: android/basic_operating_mechanism/java_layer/dex/dex-zh.md 
-                    - ODEX: android/basic_operating_mechanism/java_layer/dex/odex-zh.md 
+                    - DEX: android/basic_operating_mechanism/java_layer/dex/dex-zh.md
+                    - ODEX: android/basic_operating_mechanism/java_layer/dex/odex-zh.md
             - Android Native Layer Introduction:
                 - Android SO: android/basic_operating_mechanism/native_layer/so-zh.md
 
@@ -314,10 +314,10 @@ theme:
   palette:
     primary: 'white'
     accent: 'red'
-  logo:
-    icon: 'school'
-  feature:
-    tabs: true 
+  icon:
+    logo: 'material/school'
+  features:
+    - tabs
   font:
     text: 'Noto Sans'
     code: 'Source Code Pro'
@@ -341,9 +341,9 @@ extra_css:
 markdown_extensions:
     - admonition
     - codehilite:
-        guess_lang: false 
-    - def_list 
-    - footnotes 
+        guess_lang: false
+    - def_list
+    - footnotes
     - meta
     - toc:
         permalink: true


### PR DESCRIPTION
## Motivation

Fix the bug reported in https://github.com/ctf-wiki/ctf-wiki/issues/618#issuecomment-615434077 (that `mkdocs build` fails with `mkdocs-material >= v5.0` )

Closes #618 (possibly)

## Changes
This commit changes both the `mkdocs.yml` and `mkdocs-zh.yml`

The changes are made following the guidance of https://squidfunk.github.io/mkdocs-material/releases/5/#how-to-upgrade
