### PR TITLE
Remove unwanted typora-root-url

### DIFF
--- a/docs/crypto/asymmetric/lattice/lattice-reduction-zh.md
+++ b/docs/crypto/asymmetric/lattice/lattice-reduction-zh.md
@@ -1,7 +1,4 @@
 [EN](./lattice-reduction.md) | [ZH](./lattice-reduction-zh.md)
----
-typora-root-url: ../../../
----
 
 # 格基规约算法
 

--- a/docs/crypto/asymmetric/lattice/lattice-reduction.md
+++ b/docs/crypto/asymmetric/lattice/lattice-reduction.md
@@ -1,11 +1,4 @@
 [EN](./lattice-reduction.md) | [ZH](./lattice-reduction-zh.md)
----
-
-typora-root-url: ../../../
-
----
-
-
 
 #格基规约
 

--- a/docs/crypto/asymmetric/rsa/rsa_coppersmith_attack-zh.md
+++ b/docs/crypto/asymmetric/rsa/rsa_coppersmith_attack-zh.md
@@ -1,7 +1,4 @@
 [EN](./rsa_coppersmith_attack.md) | [ZH](./rsa_coppersmith_attack-zh.md)
----
-typora-root-url: ../../../
----
 
 # Coppersmith 相关攻击
 

--- a/docs/crypto/blockcipher/aes-zh.md
+++ b/docs/crypto/blockcipher/aes-zh.md
@@ -1,7 +1,4 @@
 [EN](./aes.md) | [ZH](./aes-zh.md)
----
-typora-root-url: ../../
----
 
 # AES
 

--- a/docs/crypto/blockcipher/des-zh.md
+++ b/docs/crypto/blockcipher/des-zh.md
@@ -1,7 +1,4 @@
 [EN](./des.md) | [ZH](./des-zh.md)
----
-typora-root-url: ../../
----
 
 # DES
 

--- a/docs/crypto/blockcipher/des.md
+++ b/docs/crypto/blockcipher/des.md
@@ -1,11 +1,4 @@
 [EN](./des.md) | [ZH](./des-zh.md)
----
-
-typora-root-url: ../../
-
----
-
-
 
 # DES
 

--- a/docs/executable/elf/elf-structure-zh.md
+++ b/docs/executable/elf/elf-structure-zh.md
@@ -1,8 +1,4 @@
 [EN](./elf-structure.md) | [ZH](./elf-structure-zh.md)
----
-typora-root-url: ../../../docs
----
-
 
 # ELF 文件
 

--- a/docs/executable/elf/program-linking-zh.md
+++ b/docs/executable/elf/program-linking-zh.md
@@ -1,8 +1,4 @@
 [EN](./program-linking.md) | [ZH](./program-linking-zh.md)
----
-typora-root-url: ../../../docs
----
-
 
 # 程序链接
 

--- a/docs/executable/elf/program-linking.md
+++ b/docs/executable/elf/program-linking.md
@@ -1,13 +1,4 @@
 [EN](./program-linking.md) | [ZH](./program-linking-zh.md)
----
-
-typora-root-url: ../../../docs
-
----
-
-
-
-
 
 #程序链接
 

--- a/docs/introduction/mode-zh.md
+++ b/docs/introduction/mode-zh.md
@@ -1,7 +1,4 @@
 [EN](./mode.md) | [ZH](./mode-zh.md)
----
-typora-root-url: ../
----
 
 ## 解题模式 - Jeopardy
 

--- a/docs/introduction/mode.md
+++ b/docs/introduction/mode.md
@@ -1,11 +1,4 @@
 [EN](./mode.md) | [ZH](./mode-zh.md)
----
-
-typora-root-url: ../
-
----
-
-
 
 ## Problem Solving Mode - Jeopardy
 

--- a/docs/misc/encode/computer-zh.md
+++ b/docs/misc/encode/computer-zh.md
@@ -1,7 +1,4 @@
 [EN](./computer.md) | [ZH](./computer-zh.md)
----
-typora-root-url: ../../
----
 
 本节介绍一些计算机相关的编码。
 

--- a/docs/misc/encode/computer.md
+++ b/docs/misc/encode/computer.md
@@ -1,11 +1,4 @@
 [EN](./computer.md) | [ZH](./computer-zh.md)
----
-
-typora-root-url: ../../
-
----
-
-
 
 This section describes some computer related coding.
 

--- a/docs/pwn/linux/glibc-heap/fastbin_attack-zh.md
+++ b/docs/pwn/linux/glibc-heap/fastbin_attack-zh.md
@@ -1,7 +1,4 @@
 [EN](./fastbin_attack.md) | [ZH](./fastbin_attack-zh.md)
----
-typora-root-url: ../../../docs
----
 
 # Fastbin Attack
 

--- a/docs/pwn/linux/glibc-heap/heap_overview-zh.md
+++ b/docs/pwn/linux/glibc-heap/heap_overview-zh.md
@@ -1,7 +1,4 @@
 [EN](./heap_overview.md) | [ZH](./heap_overview-zh.md)
----
-typora-root-url: ../../../docs
----
 
 # 堆概述
 

--- a/docs/pwn/linux/glibc-heap/heap_overview.md
+++ b/docs/pwn/linux/glibc-heap/heap_overview.md
@@ -1,11 +1,4 @@
 [EN](./heap_overview.md) | [ZH](./heap_overview-zh.md)
----
-
-typora-root-url: ../../../docs
-
----
-
-
 
 #堆 overview
 

--- a/docs/pwn/linux/glibc-heap/house_of_einherjar-zh.md
+++ b/docs/pwn/linux/glibc-heap/house_of_einherjar-zh.md
@@ -1,7 +1,4 @@
 [EN](./house_of_einherjar.md) | [ZH](./house_of_einherjar-zh.md)
----
-typora-root-url: ../../../docs
----
 
 #  House Of Einherjar
 

--- a/docs/pwn/linux/glibc-heap/house_of_einherjar.md
+++ b/docs/pwn/linux/glibc-heap/house_of_einherjar.md
@@ -1,11 +1,4 @@
 [EN](./house_of_einherjar.md) | [ZH](./house_of_einherjar-zh.md)
----
-
-typora-root-url: ../../../docs
-
----
-
-
 
 #  House Of Einherjar
 

--- a/docs/pwn/linux/glibc-heap/unlink-zh.md
+++ b/docs/pwn/linux/glibc-heap/unlink-zh.md
@@ -1,7 +1,4 @@
 [EN](./unlink.md) | [ZH](./unlink-zh.md)
----
-typora-root-url: ../../../docs
----
 
 # Unlink
 

--- a/docs/pwn/linux/glibc-heap/unsorted_bin_attack-zh.md
+++ b/docs/pwn/linux/glibc-heap/unsorted_bin_attack-zh.md
@@ -1,7 +1,4 @@
 [EN](./unsorted_bin_attack.md) | [ZH](./unsorted_bin_attack-zh.md)
----
-typora-root-url: ../../../docs
----
 
 # Unsorted Bin Attack
 

--- a/docs/pwn/linux/glibc-heap/unsorted_bin_attack.md
+++ b/docs/pwn/linux/glibc-heap/unsorted_bin_attack.md
@@ -1,11 +1,4 @@
 [EN](./unsorted_bin_attack.md) | [ZH](./unsorted_bin_attack-zh.md)
----
-
-typora-root-url: ../../../docs
-
----
-
-
 
 # Unsorted Bin Attack
 

--- a/docs/pwn/linux/integeroverflow/intof-zh.md
+++ b/docs/pwn/linux/integeroverflow/intof-zh.md
@@ -1,7 +1,4 @@
 [EN](./intof.md) | [ZH](./intof-zh.md)
----
-typora-root-url: ../../../docs
----
 
 # 整数溢出
 
@@ -185,5 +182,3 @@ aaaaaaaaaaaa
 ## CTF例题
 
 题目：[Pwnhub 故事的开始 calc](http://atum.li/2016/12/05/calc/)
-
-

--- a/docs/pwn/linux/integeroverflow/intof.md
+++ b/docs/pwn/linux/integeroverflow/intof.md
@@ -1,11 +1,4 @@
 [EN](./intof.md) | [ZH](./intof-zh.md)
----
-
-typora-root-url: ../../../docs
-
----
-
-
 
 # integer overflow
 
@@ -310,6 +303,3 @@ The two cases in the above example have a commonality, that is, the formal param
 
 
 Title: [Pwnhub Story&#39;s Beginning Cal] (http://atum.li/2016/12/05/calc/)
-
-
-

--- a/docs/pwn/linux/race-condition/introduction-zh.md
+++ b/docs/pwn/linux/race-condition/introduction-zh.md
@@ -1,7 +1,4 @@
 [EN](./introduction.md) | [ZH](./introduction-zh.md)
----
-typora-root-url: ../../../docs
----
 
 # Race Condition
 

--- a/docs/pwn/linux/race-condition/introduction.md
+++ b/docs/pwn/linux/race-condition/introduction.md
@@ -1,11 +1,4 @@
 [EN](./introduction.md) | [ZH](./introduction-zh.md)
----
-
-typora-root-url: ../../../docs
-
----
-
-
 
 # Race Condition
 

--- a/docs/pwn/linux/sandbox/python-sandbox-escape-zh.md
+++ b/docs/pwn/linux/sandbox/python-sandbox-escape-zh.md
@@ -1,7 +1,4 @@
 [EN](./python-sandbox-escape.md) | [ZH](./python-sandbox-escape-zh.md)
----
-typora-root-url: ../../../docs
----
 
 # Python 沙盒
 所谓的 Python 沙盒，即以一定的方法模拟 Python 终端，实现用户对 Python 的使用。

--- a/docs/pwn/linux/sandbox/python-sandbox-escape.md
+++ b/docs/pwn/linux/sandbox/python-sandbox-escape.md
@@ -1,11 +1,4 @@
 [EN](./python-sandbox-escape.md) | [ZH](./python-sandbox-escape-zh.md)
----
-
-typora-root-url: ../../../docs
-
----
-
-
 
 # Python sandbox
 The so-called Python sandbox, in a certain way to simulate the Python terminal, to achieve user use of Python.

--- a/docs/reverse/Identify-Encode-Encryption/introduction-zh.md
+++ b/docs/reverse/Identify-Encode-Encryption/introduction-zh.md
@@ -1,7 +1,5 @@
 [EN](./introduction.md) | [ZH](./introduction-zh.md)
----
-typora-root-url: ../../../docs
----
+
 ## 前言
 
 在对数据进行变换的过程中，除了简单的字节操作之外，还会使用一些常用的编码加密算法，因此如果能够快速识别出对应的编码或者加密算法，就能更快的分析出整个完整的算法。CTF 逆向中通常出现的加密算法包括base64、TEA、AES、RC4、MD5等。
@@ -227,4 +225,3 @@ var int digest := h0 append h1 append h2 append h3 //(expressed as little-endian
     h2 = 0x98badcfe;
     h3 = 0x10325476;
 ```
-

--- a/docs/reverse/Identify-Encode-Encryption/introduction.md
+++ b/docs/reverse/Identify-Encode-Encryption/introduction.md
@@ -1,9 +1,4 @@
 [EN](./introduction.md) | [ZH](./introduction-zh.md)
----
-
-typora-root-url: ../../../docs
-
----
 
 ## Foreword
 
@@ -405,5 +400,3 @@ Its distinctive features are:
     h3 = 0x10325476;
 
 ```
-
-


### PR DESCRIPTION
Fixes #673

This commit searches and removes all `typora-root-url` entries in the `.md` files
It aims to remove the unwanted header at the top of each document
