### PR TITLE
修复 RSA 介绍 中的 typo

### DIFF
--- a/docs/crypto/asymmetric/rsa/rsa_theory-zh.md
+++ b/docs/crypto/asymmetric/rsa/rsa_theory-zh.md
@@ -133,7 +133,7 @@ $$
 
 #### gmpy2
 
-安装时，可能会需要自己另行安装 mfpr 与 mpc 库。
+安装时，可能会需要自己另行安装 mpfr 与 mpc 库。
 
 - `gmpy2.iroot(a, b)`，类似于 `gmpy.root(a,b)`
 

--- a/docs/crypto/asymmetric/rsa/rsa_theory.md
+++ b/docs/crypto/asymmetric/rsa/rsa_theory.md
@@ -188,7 +188,7 @@ The integer decomposition library contains many algorithms for integer decomposi
 
 
 
-When installing, you may need to install the mfpr and mpc libraries separately.
+When installing, you may need to install the mpfr and mpc libraries separately.
 
 
 - `gmpy2.iroot(a, b)`, similar to `gmpy.root(a,b)`


### PR DESCRIPTION
原文 `mfpr` ，应为 `mpfr`。