### PR TITLE
Minor Typo Fix in docs/misc/audio

### DIFF
--- a/docs/misc/audio/introduction-zh.md
+++ b/docs/misc/audio/introduction-zh.md
@@ -88,7 +88,7 @@ Base64 && Base32 后得到 flag。
 
 > 2015 广东省强网杯 - Little Apple
 
-直接使用 `slienteye` 即可。
+直接使用 `silenteye` 即可。
 
 ![](./figure/2.jpg)
 

--- a/docs/misc/audio/introduction.md
+++ b/docs/misc/audio/introduction.md
@@ -149,7 +149,7 @@ Similar to the LSB steganography in image steganography, there is also a corresp
 &gt; 2015 Guangdong Strong Net Cup - Little Apple
 
 
-Just use `slienteye`.
+Just use `silenteye`.
 
 
 ![](./figure/2.jpg)


### PR DESCRIPTION
Minor Typo Fix: 
- in docs/misc/audio/introduction-zh.md and
  docs/misc/audio/introduction.md
    The tool name is silenteye, not 'slienteye'
