### PR TITLE
fix broken png link

### DIFF
--- a/docs/pwn/linux/kernel/double-fetch.md
+++ b/docs/pwn/linux/kernel/double-fetch.md
@@ -17,7 +17,7 @@ A typical `Double Fetch` vulnerability principle is shown in the following figur
 
 
 
-[Typical Double Fetch Schematic] (./double-fetch.png)
+[Typical Double Fetch Schematic](./double-fetch.png)
 
 
 ## 2018 0CTF Finals Baby Kernel


### PR DESCRIPTION
docs/pwn/linux/kernel/double-fetch.md

`- [Typical Double Fetch Schematic] (./double-fetch.png)`
`+ [Typical Double Fetch Schematic](./double-fetch.png)`