### PR TITLE
fix typo in tcache implementation page

### DIFF
--- a/docs/zh/docs/pwn/linux/glibc-heap/implementation/tcache.md
+++ b/docs/zh/docs/pwn/linux/glibc-heap/implementation/tcache.md
@@ -49,7 +49,7 @@ typedef struct tcache_perthread_struct
 static __thread tcache_perthread_struct *tcache = NULL;
 ```
 
-每个 thread 都会维护一个 `tcache_prethread_struct`，它是整个 tcache 的管理结构，一共有 `TCACHE_MAX_BINS` 个计数器和 `TCACHE_MAX_BINS`项 tcache_entry，其中
+每个 thread 都会维护一个 `tcache_perthread_struct`，它是整个 tcache 的管理结构，一共有 `TCACHE_MAX_BINS` 个计数器和 `TCACHE_MAX_BINS`项 tcache_entry，其中
 
 - `tcache_entry` 用单向链表的方式链接了相同大小的处于空闲状态（free 后）的 chunk，这一点上和 fastbin 很像。
 - `counts` 记录了 `tcache_entry` 链上空闲 chunk 的数目，每条链上最多可以有 7 个 chunk。
@@ -60,7 +60,7 @@ static __thread tcache_perthread_struct *tcache = NULL;
 
 
 ## 基本工作方式
-- 第一次 malloc 时，会先 malloc 一块内存用来存放 `tcache_prethread_struct` 。
+- 第一次 malloc 时，会先 malloc 一块内存用来存放 `tcache_perthread_struct` 。
 - free 内存，且 size 小于 small bin size 时
   - tcache 之前会放到 fastbin 或者 unsorted bin 中
   - tcache 后：
@@ -124,7 +124,7 @@ tcache_init(void)
   if (tcache_shutting_down)
     return;
   arena_get (ar_ptr, bytes); // 找到可用的 arena
-  victim = _int_malloc (ar_ptr, bytes); // 申请一个 sizeof(tcache_prethread_struct) 大小的 chunk
+  victim = _int_malloc (ar_ptr, bytes); // 申请一个 sizeof(tcache_perthread_struct) 大小的 chunk
   if (!victim && ar_ptr != NULL)
     {
       ar_ptr = arena_get_retry (ar_ptr, bytes);
@@ -145,7 +145,7 @@ tcache_init(void)
 }
 ```
 
-`tcache_init()` 成功返回后，`tcache_prethread_struct` 就被成功建立了。
+`tcache_init()` 成功返回后，`tcache_perthread_struct` 就被成功建立了。
 
 ### 申请内存
 接下来将进入申请内存的步骤

--- a/docs/zh/docs/pwn/linux/glibc-heap/tcache_attack.md
+++ b/docs/zh/docs/pwn/linux/glibc-heap/tcache_attack.md
@@ -411,7 +411,7 @@ $3 = {
   entries = {0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x555555756260, 0x0 <repeats 56 times>}
 }
 ```
-可以看到，此时第 8 条 tcache 链上已经有了一个 chunk，从 `tcache_prethread_struct` 结构体中也能得到同样的结论 
+可以看到，此时第 8 条 tcache 链上已经有了一个 chunk，从 `tcache_perthread_struct` 结构体中也能得到同样的结论 
 
 然后修改 tcache 的 next
 ```asm
@@ -954,9 +954,9 @@ tcache_    +------------+<---------------------------+
            |            |          |          |
            +------------+          +----------+
 ```
-这样，两次 malloc 后我们就返回了 `tcache_prethread_struct` 的地址，就可以控制整个 tcache 了。
+这样，两次 malloc 后我们就返回了 `tcache_perthread_struct` 的地址，就可以控制整个 tcache 了。
 
-**因为 tcache_prethread_struct 也在堆上，因此这种方法一般只需要 partial overwrite 就可以达到目的。**
+**因为 tcache_perthread_struct 也在堆上，因此这种方法一般只需要 partial overwrite 就可以达到目的。**
 
 
 


### PR DESCRIPTION
It should be `tcache_perthread_struct` instead of `tcache_prethread_struct`.