### PR TITLE
修改其他连接错误

### DIFF
--- a/docs/zh/docs/pwn/linux/user-mode/heap/ptmalloc2/house-of-lore.md
+++ b/docs/zh/docs/pwn/linux/user-mode/heap/ptmalloc2/house-of-lore.md
@@ -184,4 +184,4 @@ int main(int argc, char * argv[]){
 
 ## 参考文献
 
-- [https://github.com/shellphish/how2heap/blob/master/glibc_2.25/house_of_lore.c](https://github.com/shellphish/how2heap/blob/master/glibc_2.25/house_of_lore.c)
+- [https://github.com/shellphish/how2heap/blob/master/glibc_2.27/house_of_lore.c](https://github.com/shellphish/how2heap/blob/master/glibc_2.27/house_of_lore.c)

--- a/docs/zh/docs/pwn/linux/user-mode/heap/ptmalloc2/tcache-attack.md
+++ b/docs/zh/docs/pwn/linux/user-mode/heap/ptmalloc2/tcache-attack.md
@@ -734,7 +734,7 @@ tcache_put (mchunkptr chunk, size_t tc_idx)
 
 因为没有任何检查，所以我们可以对同一个 chunk 多次 free，造成 cycliced list。
 
-以 how2heap 的 [tcache_dup](https://github.com/shellphish/how2heap/blob/master/glibc_2.26/tcache_dup.c) 为例分析，源码如下：
+以 how2heap 的 [tcache_dup](https://github.com/shellphish/how2heap/blob/master/glibc_2.27/tcache_dup.c) 为例分析，源码如下：
 ```C
 glibc_2.26 [master●] bat ./tcache_dup.c 
 ───────┬─────────────────────────────────────────────────────────────────────────────────

--- a/docs/zh/docs/pwn/linux/user-mode/heap/ptmalloc2/unsorted-bin-attack.md
+++ b/docs/zh/docs/pwn/linux/user-mode/heap/ptmalloc2/unsorted-bin-attack.md
@@ -113,7 +113,7 @@ main_arena_offset = ELF("libc.so.6").symbols["__malloc_hook"] + 0x10
 
 
 
-这里我以 shellphish 的 how2heap 仓库中的 [unsorted_bin_attack.c](https://github.com/shellphish/how2heap/blob/master/unsorted_bin_attack.c) 为例进行介绍，这里我做一些简单的修改，如下
+这里我以 shellphish 的 how2heap 仓库中的 [unsorted_bin_attack.c](https://github.com/shellphish/how2heap/blob/master/glibc_2.27/unsorted_bin_attack.c) 为例进行介绍，这里我做一些简单的修改，如下
 
 ```c
 #include <stdio.h>


### PR DESCRIPTION
- unsorted-bin-attack 这个文件文件原作者移动到glibc_2.27和glibc_2.23这两个文件夹中，和文中的内容不同，应该做过修改了，可以看下是否正确
- 其他的是连接错误


> 最后提个建议

写文章的时候使用commit的序列号作为连接，这样就不会有引用连接错误问题