### PR TITLE
fix(docker): Push to dockerhub by github actions

### DIFF
--- a/.github/workflows/dockerhub.yml
+++ b/.github/workflows/dockerhub.yml
@@ -1,0 +1,25 @@
+name: Update dockerhub
+
+on:
+  push:
+    branches:
+      - 'master'
+      - 'ci-docker'
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v2
+      - name: Login to DockerHub
+        uses: docker/login-action@v1 
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Build and push
+        id: docker_build
+        uses: docker/build-push-action@v2
+        with:
+          push: true
+          tags: ctfwiki/ctf-wiki:latest

--- a/README-zh_CN.md
+++ b/README-zh_CN.md
@@ -59,13 +59,8 @@ python3 scripts/docs.py serve
 
 如果你只是想本地浏览，并不想修改文档？试试 Docker 把！
 
-> 注意：在 DockerHub 上的 `ctfwiki/ctf-wiki` 为过时版本，您可使用以下命令手动构建。
-
 ```
-# docker run -d --name=ctf-wiki -p 4100:80 ctfwiki/ctf-wiki
-git clone https://github.com/ctf-wiki/ctf-wiki.git
-docker build -t ctf-wiki .
-docker run --name ctf-wiki -d -p 4100:80 ctf-wiki
+docker run -d --name=ctf-wiki -p 4100:80 ctfwiki/ctf-wiki
 ```
 随后即可在浏览器中访问 [http://localhost:4100/](http://localhost:4100/) 阅读 CTF Wiki 。
 

--- a/README.md
+++ b/README.md
@@ -58,13 +58,8 @@ python3 scripts/docs.py serve
 
 If you just want to view it statically, try Docker!
 
-> Note: The `ctfwiki/ctf-wiki` on DockerHub is out of date, but you can manually build it using the following command
-
 ```
-# docker run -d --name=ctf-wiki -p 4100:80 ctfwiki/ctf-wiki
-git clone https://github.com/ctf-wiki/ctf-wiki.git
-docker build -t ctf-wiki .
-docker run --name ctf-wiki -d -p 4100:80 ctf-wiki
+docker run -d --name=ctf-wiki -p 4100:80 ctfwiki/ctf-wiki
 ```
 And then access [http://localhost:4100/](http://localhost:4100/) .
 


### PR DESCRIPTION
Dockerhub build became premium feature that we can't use for free.
So we change to use Github Actions to build the docker images and
push to Dockerhub.
