### PR TITLE
Add missing command before constructing `_install`

### DIFF
--- a/docs/zh/docs/pwn/linux/kernel-mode/environment/qemu-emulate.md
+++ b/docs/zh/docs/pwn/linux/kernel-mode/environment/qemu-emulate.md
@@ -41,6 +41,12 @@ make -j3
 
 #### 配置文件系统
 
+使用 busybox 创建 `_install` 目录，使用命令：
+
+```bash
+make install
+```
+
 在编译完成后，我们在 `_install` 目录下创建以下文件夹
 
 ```bash


### PR DESCRIPTION
After `make`, busybox only generates the binary, without construct `_install` directory.
After `make install`, `_install` is generated.
Maybe the author forgets this command. 