### PR TITLE
fix one typo

### DIFF
--- a/docs/zh/docs/crypto/asymmetric/rsa/rsa_module_attack.md
+++ b/docs/zh/docs/crypto/asymmetric/rsa/rsa_module_attack.md
@@ -123,7 +123,7 @@ $$
         a = powmod(a, n, N)
         res = gcd(a-1, N)
         if res != 1 and res != N:
-            q = n // res
+            q = N // res
             d = invert(e, (res-1)*(q-1))
             m = powmod(c, d, N)
             print(m)


### PR DESCRIPTION
In pollard's p-1 smooth code, q should be divided by N, not n

Thanks for contributing to CTF Wiki!

**Before submitting this pull request, please read**
- [Contribute](https://ctf-wiki.org/contribute/before-contributing/)
- [CTF Wiki's Wiki](https://github.com/ctf-wiki/ctf-wiki/wiki)

**Please remove these message before PR.**
