### PR TITLE
Update index.md

### DIFF
--- a/docs/zh/docs/index.md
+++ b/docs/zh/docs/index.md
@@ -1,7 +1,5 @@
 # 简介
 
-[![Build Status](https://travis-ci.org/ctf-wiki/ctf-wiki.svg?branch=master)](https://travis-ci.org/ctf-wiki/ctf-wiki)
-[![Requirements Status](https://requires.io/github/ctf-wiki/ctf-wiki/requirements.svg?branch=master)](https://requires.io/github/ctf-wiki/ctf-wiki/requirements/?branch=master)
 [![Slack](https://img.shields.io/badge/slack-join%20chat-brightgreen.svg)](https://join.slack.com/t/ctf-wiki/shared_invite/enQtNTkwNDg5NDUzNzAzLWExOTRhZTE0ZTMzYjVlNDk5OGI3ZDA1NmQyZjE4NWRlMGU3NjEwM2Y2ZTliMTg4Njg1MjliNWRhNTk2ZmY0NmI)
 
 欢迎来到 **CTF Wiki**。


### PR DESCRIPTION
根据Requires.io跳转的http://shiningpanda.com/requires-io-clap-de-fin/显示，Requires.io已经于2022年11月30日停止服务，此信息也无法正常显示。另外一个信息同样无法显示，不知道是我的问题还是服务同样停止、
如果有问题，各位可以直接修改，我开权限了.....吧
Thanks for contributing to CTF Wiki!

**Before submitting this pull request, please read**
- [Contribute](https://ctf-wiki.org/contribute/before-contributing/)
- [CTF Wiki's Wiki](https://github.com/ctf-wiki/ctf-wiki/wiki)

**Please remove these message before PR.**
