### PR TITLE
 update mkdocs.yml

### DIFF
--- a/docs/zh/mkdocs.yml
+++ b/docs/zh/mkdocs.yml
@@ -49,6 +49,7 @@ nav:
 - Misc:
   - misc/introduction.md
   - misc/recon.md
+  - misc/others.md
   - 编码分析:
     - misc/encode/communication.md
     - misc/encode/computer.md
@@ -199,6 +200,11 @@ nav:
   - assembly/arm/readme.md
 - Executable:
   - ELF 文件:
+    - PE  文件基本结构:
+      - executable/pe/pe-excutable.md
+      - executable/pe/pe-export-table.md
+      - executable/pe/pe-import-table.md
+      - executable/pe/pe-relocation-table.md
     - ELF 文件基本结构:
       - executable/elf/structure/basic-info.md
       - executable/elf/structure/sections.md
@@ -274,6 +280,7 @@ nav:
         - reverse/platform/windows/anti-debug/zwsetinformationthread.md
         - reverse/platform/windows/anti-debug/junk-code.md
         - reverse/platform/windows/anti-debug/example.md
+        - reverse/platform/windows/anti-debug/thread_local_storage.md
   - Language related:
     - reverse/language/introduction.md
     - Python:
@@ -343,6 +350,8 @@ nav:
             - pwn/linux/user-mode/heap/ptmalloc2/house-of-rabbit.md
             - pwn/linux/user-mode/heap/ptmalloc2/house-of-roman.md
             - pwn/linux/user-mode/heap/ptmalloc2/house-of-pig.md
+            - pwn/linux/user-mode/heap/ptmalloc2/leak-heap.md
+            - pwn/linux/user-mode/heap/ptmalloc2/ptmalloc-check.md
           - Musl-mallocng:
             - pwn/linux/user-mode/heap/mallocng/readme.md
         - IO_FILE Exploitation:
@@ -372,6 +381,7 @@ nav:
         - pwn/linux/kernel-mode/environment/build-kernel-module.md
         - pwn/linux/kernel-mode/environment/qemu-emulate.md
         - pwn/linux/kernel-mode/environment/real-device.md
+        - pwn/linux/kernel-mode/environment/System.map.md
       - Basic Knowledge:
         - pwn/linux/kernel-mode/basic-knowledge.md
       - Aim:
@@ -433,8 +443,11 @@ nav:
         - pwn/windows/user-mode/stackoverflow/stack-introduction.md
         - pwn/windows/user-mode/stackoverflow/stackoverflow-basic.md
         - pwn/windows/user-mode/stackoverflow/shellcode-in-stack.md
+        - pwn/windows/user-mode/stackoverflow/ret2dll.md
     - Kernel Mode:
       - pwn/windows/kernel-mode/readme.md
+      - Basic Knowledge:
+        - pwn/windows/kernel-mode/basic-knowledge/introduction.md
   - MacOS Platform:
     - pwn/macos/readme.md
   - Misc OS Platform:
@@ -467,6 +480,7 @@ nav:
         - pwn/virtualization/qemu/environment/build-qemu-dev.md
       - Exploitation:
         - pwn/virtualization/qemu/exploitation/intro.md
+        - pwn/virtualization/qemu/exploitation/oob.md
     - Virtual Box:
       - pwn/virtualization/virtualbox/readme.md
     - VMWare:
@@ -488,6 +502,7 @@ nav:
     - 可信计算:
       - pwn/hardware/trusted-computing/tee.md
 - Android:
+  - android/readme.md
   - android/basic_develop/basic_develop.md
   - Android 运行机制简述:
     - android/basic_operating_mechanism/readme.md
@@ -509,6 +524,7 @@ nav:
     - Android 简单动态分析:
       - android/basic_reverse/dynamic/dynamic_debug.md
       - android/basic_reverse/dynamic/ida_native_debug.md
+      - android/basic_reverse/dynamic/ida_smali_debug.md
 - ICS:
   - ics/ctfs.md
   - ics/discover.md


### PR DESCRIPTION
INFO    -  The following pages exist in the docs directory, but are not included in the "nav" configuration:
             - android/readme.md
             - android/basic_reverse/dynamic/ida_smali_debug.md
             - executable/pe/pe-excutable.md
             - executable/pe/pe-export-table.md
             - executable/pe/pe-import-table.md
             - executable/pe/pe-relocation-table.md
             - misc/others.md
             - pwn/linux/kernel-mode/environment/System.map.md
             - pwn/linux/user-mode/heap/ptmalloc2/leak-heap.md
             - pwn/linux/user-mode/heap/ptmalloc2/ptmalloc-check.md
             - pwn/virtualization/qemu/exploitation/oob.md
             - pwn/windows/kernel-mode/basic-knowledge/introduction.md
             - pwn/windows/user-mode/stackoverflow/ret2dll.md
             - reverse/platform/windows/anti-debug/thread_local_storage.md