### PR TITLE
fix spelling errors for https://github.com/ctf-wiki/ctf-wiki/issues/949

### DIFF
--- a/docs/zh/docs/pwn/linux/kernel-mode/environment/qemu-emulate.md
+++ b/docs/zh/docs/pwn/linux/kernel-mode/environment/qemu-emulate.md
@@ -70,11 +70,11 @@ $ touch etc/init.d/rcS
 $ chmod +x ./etc/init.d/rcS
 ```
 
-在我们创建的 `./etc/inttab` 中写入如下内容：
+在我们创建的 `./etc/inittab` 中写入如下内容：
 
 ```shell
 ::sysinit:/etc/init.d/rcS
-::askfirst:/bin/ash
+::askfirst:/bin/sh
 ::ctrlaltdel:/sbin/reboot
 ::shutdown:/sbin/swapoff -a
 ::shutdown:/bin/umount -a -r


### PR DESCRIPTION
在搭建内核运行环境的编译 BusyBox文档中 https://ctf-wiki.org/pwn/linux/kernel-mode/environment/qemu-emulate/#busybox_3
有两处错误非常致命，会导致编译的busybox无法使用。
具体的文件在 docs/zh/docs/pwn/linux/kernel-mode/environment/qemu-emulate.md 中

将 “在我们创建的 ./etc/inttab 中写入如下内容：” 改成 “在我们创建的 ./etc/inittab 中写入如下内容：”。也就是将./etc/inttab 改成 ./etc/inittab
将 ::askfirst:/bin/ash 改成 ::askfirst:/bin/sh
